### PR TITLE
Fix description slashes in multisite for site admins

### DIFF
--- a/image-widget.php
+++ b/image-widget.php
@@ -127,7 +127,7 @@ class Tribe_Image_Widget extends WP_Widget {
 		if ( current_user_can('unfiltered_html') ) {
 			$instance['description'] = $new_instance['description'];
 		} else {
-			$instance['description'] = wp_filter_post_kses($new_instance['description']);
+			$instance['description'] = stripslashes( wp_filter_post_kses( addslashes($new_instance['description']) ) );
 		}
 		$instance['link'] = $new_instance['link'];
 		$instance['linktarget'] = $new_instance['linktarget'];


### PR DESCRIPTION
Fix description slashes in multisite for site admins, without the 'unfiltered_html' capability.

See https://core.trac.wordpress.org/changeset/12364
