### PR TITLE
Add customizable link ID attribute

### DIFF
--- a/image-widget.php
+++ b/image-widget.php
@@ -92,6 +92,7 @@ class Tribe_Image_Widget extends WP_Widget {
 			$instance['title'] = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'] );
 			$instance['description'] = apply_filters( 'widget_text', $instance['description'], $args, $instance );
 			$instance['link'] = apply_filters( 'image_widget_image_link', esc_url( $instance['link'] ), $args, $instance );
+			$instance['linkid'] = apply_filters( 'image_widget_image_link_id', esc_attr( $instance['linkid'] ), $args, $instance );
 			$instance['linktarget'] = apply_filters( 'image_widget_image_link_target', esc_attr( $instance['linktarget'] ), $args, $instance );
 			$instance['width'] = apply_filters( 'image_widget_image_width', abs( $instance['width'] ), $args, $instance );
 			$instance['height'] = apply_filters( 'image_widget_image_height', abs( $instance['height'] ), $args, $instance );
@@ -132,6 +133,7 @@ class Tribe_Image_Widget extends WP_Widget {
 			$instance['description'] = wp_filter_post_kses($new_instance['description']);
 		}
 		$instance['link'] = $new_instance['link'];
+		$instance['linkid'] = $new_instance['linkid'];
 		$instance['linktarget'] = $new_instance['linktarget'];
 		$instance['width'] = abs( $new_instance['width'] );
 		$instance['height'] =abs( $new_instance['height'] );
@@ -214,6 +216,7 @@ class Tribe_Image_Widget extends WP_Widget {
 			'title' => '',
 			'description' => '',
 			'link' => '',
+			'linkid' => '',
 			'linktarget' => '',
 			'width' => 0,
 			'height' => 0,
@@ -252,6 +255,7 @@ class Tribe_Image_Widget extends WP_Widget {
 		if ( $include_link && !empty( $instance['link'] ) ) {
 			$attr = array(
 				'href' => $instance['link'],
+				'id' => $instance['linkid'],
 				'target' => $instance['linktarget'],
 				'class' => 	$this->widget_options['classname'].'-image-link',
 				'title' => ( !empty( $instance['alt'] ) ) ? $instance['alt'] : $instance['title'],

--- a/views/widget-admin.php
+++ b/views/widget-admin.php
@@ -31,6 +31,8 @@ if ( !defined('ABSPATH') )
 
 	<p><label for="<?php echo $this->get_field_id('link'); ?>"><?php _e('Link', 'image_widget'); ?>:</label>
 	<input class="widefat" id="<?php echo $this->get_field_id('link'); ?>" name="<?php echo $this->get_field_name('link'); ?>" type="text" value="<?php echo esc_attr(strip_tags($instance['link'])); ?>" /><br />
+	<label for="<?php echo $this->get_field_id('linkid'); ?>"><?php _e('Link ID', 'image_widget'); ?>:</label>
+	<input class="widefat" id="<?php echo $this->get_field_id('linkid'); ?>" name="<?php echo $this->get_field_name('linkid'); ?>" type="text" value="<?php echo esc_attr(strip_tags($instance['linkid'])); ?>" /><br />
 	<select name="<?php echo $this->get_field_name('linktarget'); ?>" id="<?php echo $this->get_field_id('linktarget'); ?>">
 		<option value="_self"<?php selected( $instance['linktarget'], '_self' ); ?>><?php _e('Stay in Window', 'image_widget'); ?></option>
 		<option value="_blank"<?php selected( $instance['linktarget'], '_blank' ); ?>><?php _e('Open New Window', 'image_widget'); ?></option>


### PR DESCRIPTION
This allows a user to create a custom ```id``` attribute on the ```<a>``` element, as required for Google Analytics Enhanced Link Attribution. 