### PR TITLE
Extend image size choices to include all registered sizes

### DIFF
--- a/image-widget.php
+++ b/image-widget.php
@@ -331,6 +331,27 @@ class Tribe_Image_Widget extends WP_Widget {
 	}
 
 	/**
+	 * Get all possible image sizes to choose from
+	 *
+	 * @return array
+	 */
+	private function possible_image_sizes() {
+		$registered = get_intermediate_image_sizes();
+		// label other sizes with their image size "ID"
+		$registered = array_combine( $registered, $registered );
+
+		$possible_sizes = array_merge( $registered, array(
+			'full'                       => __('Full Size', 'image_widget'),
+			'thumbnail'                  => __('Thumbnail', 'image_widget'),
+			'medium'                     => __('Medium', 'image_widget'),
+			'large'                      => __('Large', 'image_widget'),
+			self::CUSTOM_IMAGE_SIZE_SLUG => __('Custom', 'image_widget'),
+		) );
+
+		return (array) apply_filters( 'image_size_names_choose', $possible_sizes );
+	}
+
+	/**
 	 * Assesses the image size in case it has not been set or in case there is a mismatch.
 	 *
 	 * @param $instance

--- a/views/widget-admin.php
+++ b/views/widget-admin.php
@@ -49,19 +49,9 @@ if ( !defined('ABSPATH') )
 	<div id="<?php echo $this->get_field_id('custom_size_selector'); ?>" <?php if ( empty($instance['attachment_id']) && !empty($instance['imageurl']) ) { $instance['size'] = self::CUSTOM_IMAGE_SIZE_SLUG; ?>style="display:none;"<?php } ?>>
 		<p><label for="<?php echo $this->get_field_id('size'); ?>"><?php _e('Size', 'image_widget'); ?>:</label>
 			<select name="<?php echo $this->get_field_name('size'); ?>" id="<?php echo $this->get_field_id('size'); ?>" onChange="imageWidget.toggleSizes( '<?php echo $this->id; ?>', '<?php echo $id_prefix; ?>' );">
-				<?php
-				// Note: this is dumb. We shouldn't need to have to do this. There should really be a centralized function in core code for this.
-				$possible_sizes = apply_filters( 'image_size_names_choose', array(
-					'full'      => __('Full Size', 'image_widget'),
-					'thumbnail' => __('Thumbnail', 'image_widget'),
-					'medium'    => __('Medium', 'image_widget'),
-					'large'     => __('Large', 'image_widget'),
-				) );
-				$possible_sizes[self::CUSTOM_IMAGE_SIZE_SLUG] = __('Custom', 'image_widget');
-
-				foreach( $possible_sizes as $size_key => $size_label ) { ?>
+				<?php foreach( $this->possible_image_sizes() as $size_key => $size_label ) : ?>
 					<option value="<?php echo $size_key; ?>"<?php selected( $instance['size'], $size_key ); ?>><?php echo $size_label; ?></option>
-					<?php } ?>
+				<?php endforeach ?>
 			</select>
 		</p>
 	</div>


### PR DESCRIPTION
Pretty self-explanatory PR I think.

Previously, the widget did not allow the user to choose a different size other than the 5 sizes defined in the plugin, which only covered the default sizes included in WordPress.

Although filterable, this (as the comment says itself) is dumb, and people shouldn't have to do that.

This PR makes that possible, while maintaining compatibility with the previous code, and cleans things up a bit in the process.

**Before**
![](http://d.pr/i/Okey+)

**After**
![](http://d.pr/i/1a7WY+)