### PR TITLE
added support for srcset and sizes attributes added in wp version 4.4

### DIFF
--- a/image-widget.php
+++ b/image-widget.php
@@ -285,6 +285,14 @@ class Tribe_Image_Widget extends WP_Widget {
 				$instance['width'] = $image_details[1];
 				$instance['height'] = $image_details[2];
 			}
+			$image_srcset = wp_get_attachment_image_srcset( $instance['attachment_id'], $size);
+			if ( $image_srcset ) {
+				$instance['srcset'] = $image_srcset;
+			}
+			$image_sizes = wp_get_attachment_image_sizes( $instance['attachment_id'], $size );
+			if ( $image_sizes ) {
+				$instance['sizes'] = $image_sizes;
+			}
 		}
 		$instance['width'] = abs( $instance['width'] );
 		$instance['height'] = abs( $instance['height'] );
@@ -305,6 +313,12 @@ class Tribe_Image_Widget extends WP_Widget {
 		}
 		if (!empty($instance['align']) && $instance['align'] != 'none') {
 			$attr['class'] .= " align{$instance['align']}";
+		}
+		if (!empty($instance['srcset'])) {
+			$attr['srcset'] = $instance['srcset'];
+		}
+		if (!empty($instance['sizes'])) {
+			$attr['sizes'] = $instance['sizes'];
 		}
 		$attr = apply_filters( 'image_widget_image_attributes', $attr, $instance );
 


### PR DESCRIPTION
When using the plugin in large widget areas, such as full width, large images are being served to mobile.  I added the built in support for the 'srcset' attribute, which must also include 'sizes'.
<img width="526" alt="screen shot 2016-03-04 at 9 21 31 am" src="https://cloud.githubusercontent.com/assets/5949352/13529502/9c8af4c6-e1ea-11e5-8280-4c209b230523.png">

[#77029](https://central.tri.be/issues/77029)