### PR TITLE
fix the older WordPress compatibility issues

### DIFF
--- a/image-widget.php
+++ b/image-widget.php
@@ -292,12 +292,17 @@ class Tribe_Image_Widget extends WP_Widget {
 				$instance['height'] = $image_details[2];
 			}
 
-			$image_srcset = wp_get_attachment_image_srcset( $instance['attachment_id'], $size );
+
+			$image_srcset = function_exists( 'wp_get_attachment_image_srcset' )
+				? wp_get_attachment_image_srcset( $instance['attachment_id'], $size )
+				: false;
 			if ( $image_srcset ) {
 				$instance['srcset'] = $image_srcset;
 			}
 
- 			$image_sizes = wp_get_attachment_image_sizes( $instance['attachment_id'], $size );
+ 			$image_sizes = function_exists( 'wp_get_attachment_image_sizes' )
+				? wp_get_attachment_image_sizes( $instance['attachment_id'], $size )
+				: false;
  			if ( $image_sizes ) {
 				$instance['sizes'] = $image_sizes;
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -207,6 +207,11 @@ For more info on the philosophy here, check out our [blog post](http://tri.be/de
 
 == Changelog ==
 
+= unreleased =
+
+* Fix - fixed compatibility with WordPress versions prior to 4.4
+* Fix - proportional scaling of image within the widget editor
+
 = 4.4.1 =
 
 * Fix - fixed some broken links


### PR DESCRIPTION
Reported to us here: https://github.com/moderntribe/image-widget/pull/20#issuecomment-296154106

Also: added readme entry for changes in PR #31
