### PR TITLE
fix validation issues

### DIFF
--- a/image-widget.php
+++ b/image-widget.php
@@ -301,8 +301,8 @@ class Tribe_Image_Widget extends WP_Widget {
 				$instance['srcset'] = $image_srcset;
 
 				$image_sizes = function_exists( 'wp_get_attachment_image_sizes' )
-				? wp_get_attachment_image_sizes( $instance['attachment_id'], $size )
-				: false;
+					? wp_get_attachment_image_sizes( $instance['attachment_id'], $size )
+					: false;
 	 			if ( $image_sizes ) {
 					$instance['sizes'] = $image_sizes;
 				}

--- a/image-widget.php
+++ b/image-widget.php
@@ -274,7 +274,9 @@ class Tribe_Image_Widget extends WP_Widget {
 			$attr = array_map( 'esc_attr', $attr );
 			$output = '<a';
 			foreach ( $attr as $name => $value ) {
-				$output .= sprintf( ' %s="%s"', $name, $value );
+				if ( ! empty( $value ) ) {
+					$output .= sprintf( ' %s="%s"', $name, $value );
+				}
 			}
 			$output .= '>';
 		}
@@ -292,44 +294,54 @@ class Tribe_Image_Widget extends WP_Widget {
 				$instance['height'] = $image_details[2];
 			}
 
-
 			$image_srcset = function_exists( 'wp_get_attachment_image_srcset' )
 				? wp_get_attachment_image_srcset( $instance['attachment_id'], $size )
 				: false;
 			if ( $image_srcset ) {
 				$instance['srcset'] = $image_srcset;
-			}
 
- 			$image_sizes = function_exists( 'wp_get_attachment_image_sizes' )
+				$image_sizes = function_exists( 'wp_get_attachment_image_sizes' )
 				? wp_get_attachment_image_sizes( $instance['attachment_id'], $size )
 				: false;
- 			if ( $image_sizes ) {
-				$instance['sizes'] = $image_sizes;
+	 			if ( $image_sizes ) {
+					$instance['sizes'] = $image_sizes;
+				}
 			}
 		}
 		$instance['width'] = abs( $instance['width'] );
 		$instance['height'] = abs( $instance['height'] );
 
 		$attr = array();
-		$attr['alt'] = ( ! empty( $instance['alt'] ) ) ? $instance['alt'] : $instance['title'];
+
+		if ( ! empty( $instance['alt'] ) ) {
+			$attr['alt'] = $instance['alt'];
+		} elseif ( ! empty( $instance['title'] ) ) {
+			$attr['alt'] = $instance['title'];
+		}
+
 		if ( is_array( $size ) ) {
 			$attr['class'] = 'attachment-' . join( 'x', $size );
 		} else {
 			$attr['class'] = 'attachment-' . $size;
 		}
+
 		$attr['style'] = '';
 		if ( ! empty( $instance['maxwidth'] ) ) {
 			$attr['style'] .= "max-width: {$instance['maxwidth']};";
 		}
+
 		if ( ! empty( $instance['maxheight'] ) ) {
 			$attr['style'] .= "max-height: {$instance['maxheight']};";
 		}
+
 		if ( ! empty( $instance['align'] ) && $instance['align'] != 'none' ) {
 			$attr['class'] .= " align{$instance['align']}";
 		}
+
 		if ( ! empty( $instance['srcset'] ) ) {
 			$attr['srcset'] = $instance['srcset'];
 		}
+
 		if ( ! empty( $instance['sizes'] ) ) {
 			$attr['sizes'] = $instance['sizes'];
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -207,10 +207,11 @@ For more info on the philosophy here, check out our [blog post](http://tri.be/de
 
 == Changelog ==
 
-= unreleased =
+= 4.4.2 =
 
 * Fix - fixed compatibility with WordPress versions prior to 4.4
 * Fix - proportional scaling of image within the widget editor
+* Fix - fix validation by avoiding empty attributes and only specifying sizes with srcset (thanks Zodiak1978)
 
 = 4.4.1 =
 


### PR DESCRIPTION
avoid empty attributes and only specify `sizes` with srcset

See: https://central.tri.be/issues/78357 and #33