### PR TITLE
Feature/78676 hide upsell if iw+ active

### DIFF
--- a/image-widget.php
+++ b/image-widget.php
@@ -441,6 +441,9 @@ class Tribe_Image_Widget extends WP_Widget {
 	public function post_upgrade_nag() {
 		if ( ! current_user_can( 'install_plugins' ) ) return;
 
+		// don't show the notices if Image Widget Plus is already active 
+		if ( class_exists( 'Tribe__Image__Plus__Main' ) ) return;
+
 		global $pagenow;
 		$msg = false;
 		switch ( $pagenow ) {

--- a/image-widget.php
+++ b/image-widget.php
@@ -439,10 +439,13 @@ class Tribe_Image_Widget extends WP_Widget {
 	 * Display a thank you nag when the plugin has been upgraded.
 	 */
 	public function post_upgrade_nag() {
-		if ( ! current_user_can( 'install_plugins' ) ) return;
-
-		// don't show the notices if Image Widget Plus is already active 
-		if ( class_exists( 'Tribe__Image__Plus__Main' ) ) return;
+		
+		if ( 
+			! current_user_can( 'install_plugins' ) 
+			|| class_exists( 'Tribe__Image__Plus__Main' )
+		) {
+			return;
+		}
 
 		global $pagenow;
 		$msg = false;

--- a/readme.txt
+++ b/readme.txt
@@ -208,6 +208,10 @@ For more info on the philosophy here, check out our [blog post](http://tri.be/de
 
 = 4.4.3 =
 
+* Tweak - Improve upsell notices display logic
+
+= 4.4.3 =
+
 * Fix - Fixed bug where selecting an image failed to trigger a Save & Publish in the Customizer (props to dsaric-dev for the fix)
 * Tweak - Roll-back to sidebar_admin_setup to enqueue resources for optimal plugin compatibility (props to megamenu for the heads up)
 

--- a/readme.txt
+++ b/readme.txt
@@ -206,7 +206,7 @@ For more info on the philosophy here, check out our [blog post](http://tri.be/de
 
 == Changelog ==
 
-= 4.4.3 =
+= 4.4.4 =
 
 * Tweak - Improve upsell notices display logic
 


### PR DESCRIPTION
https://central.tri.be/issues/78676

Not sure if this is the best solution, as once you deactivate Image Widget Plus it will show up. Maybe it's better to force a dismiss for both notices (the one for plugins page and the one for widgets)?

Also, couldn't find any format guidelines for comments like the one I left. So I followed what I saw in the code. Not event sure  it needs a comment thou!