### PR TITLE
Add an filter point for setting the defaults

### DIFF
--- a/image-widget.php
+++ b/image-widget.php
@@ -225,6 +225,14 @@ class Tribe_Image_Widget extends WP_Widget {
 			$defaults['size'] = self::CUSTOM_IMAGE_SIZE_SLUG;
 			$defaults['attachment_id'] = 0;
 		}
+		
+		/**
+		 * Allow users to customize the default values of various Image Widget options.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $defaults The array of default option values.
+		 */
 		return apply_filters( 'image_widget_option_defaults', $defaults ); 
 	}
 

--- a/image-widget.php
+++ b/image-widget.php
@@ -225,8 +225,7 @@ class Tribe_Image_Widget extends WP_Widget {
 			$defaults['size'] = self::CUSTOM_IMAGE_SIZE_SLUG;
 			$defaults['attachment_id'] = 0;
 		}
-
-		return apply_filters( 'image_widget_defaults', $defaults );
+		return apply_filters( 'image_widget_option_defaults', $defaults ); 
 	}
 
 	/**

--- a/image-widget.php
+++ b/image-widget.php
@@ -226,7 +226,7 @@ class Tribe_Image_Widget extends WP_Widget {
 			$defaults['attachment_id'] = 0;
 		}
 
-		return apply_filters( 'image_widget_defaults', $defaults);
+		return apply_filters( 'image_widget_defaults', $defaults );
 	}
 
 	/**

--- a/image-widget.php
+++ b/image-widget.php
@@ -224,8 +224,7 @@ class Tribe_Image_Widget extends WP_Widget {
 		if ( ! defined( 'IMAGE_WIDGET_COMPATIBILITY_TEST' ) ) {
 			$defaults['size'] = self::CUSTOM_IMAGE_SIZE_SLUG;
 			$defaults['attachment_id'] = 0;
-		}
-		
+		}		
 		/**
 		 * Allow users to customize the default values of various Image Widget options.
 		 *
@@ -233,7 +232,7 @@ class Tribe_Image_Widget extends WP_Widget {
 		 *
 		 * @param array $defaults The array of default option values.
 		 */
-		return apply_filters( 'image_widget_option_defaults', $defaults ); 
+		return apply_filters( 'image_widget_option_defaults', $defaults );
 	}
 
 	/**

--- a/image-widget.php
+++ b/image-widget.php
@@ -226,7 +226,7 @@ class Tribe_Image_Widget extends WP_Widget {
 			$defaults['attachment_id'] = 0;
 		}
 
-		return $defaults;
+		return apply_filters( 'image_widget_defaults', $defaults);
 	}
 
 	/**


### PR DESCRIPTION
Hi, we're using this plugin extensively but have cause to change the default size away from Custom (after removing the hardcoded Full Size option through the `image_size_names_choose` filter. The reason is that editors are adding enormous images into the sidebar of our site.

To achieve this, I've added a single line that adds a `image_widget_defaults` filter to add the ability to set the defaults for the image widget without changing the widget itself.

For example we're looking to use:
```
// Set the new default to medium instead of custom
add_filter( 'image_widget_defaults', function($defaults) {
	$defaults['size'] ='medium';
	return $defaults;
});
```
