### PR TITLE
Update "tested upto" field (to WP 5.2.1) | spotfix

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ModernTribe, aguseo, borkweb, barry.hughes, bordoni, brianjessee, 
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=4BSPTNFFY6AL6
 Tags: widget, image, ad, banner, simple, upload, sidebar, retina, admin, thickbox, resize, arabic, brazilian portuguese, dutch, german, hebrew, italian, japanese, polish, spanish, swedish, widget-only
 Requires at least: 3.5
-Tested up to: 4.8.3
+Tested up to: 5.2.1
 Stable tag: 4.4.7
 
 A simple image widget that uses the native WordPress media manager to add image widgets to your site.


### PR DESCRIPTION
Updating the tested upto field only (to match SVN). Plugin version bump not needed.